### PR TITLE
Drop mean

### DIFF
--- a/src/System/Remote/Monitoring/Influxdb.hs
+++ b/src/System/Remote/Monitoring/Influxdb.hs
@@ -154,8 +154,7 @@ flushSample sample params opts = do
   metrics _ (EKG.Label {}) _ = V.empty
   metrics n (EKG.Distribution stats) t =
     let f n' v = Metric ("dist." <> n <> "." <> n') v t
-    in V.fromList [ f "mean" (Stats.mean stats)
-                  , f "variance" (Stats.variance stats)
+    in V.fromList [ f "variance" (Stats.variance stats)
                   , f "count" (fromIntegral $ Stats.count stats)
                   , f "sum" (Stats.sum stats)
                   , f "min" (Stats.min stats)


### PR DESCRIPTION
This might be a bit controversial but fixes an actual issue without any actual loss. 

The issue is that for an empty data set the mean is `NaN` (see blow) which is wrapped in `FieldFloat :: Field n` and formatted to `NaN` which is not a valid float value in InfluxDB. 
```
Prelude System.Metrics.Distribution> new >>= System.Metrics.Distribution.read
Stats {mean = NaN, variance = 0.0, count = 0, sum = 0.0, min = 0.0, max = 0.0}
```
However, mean is just `sum / count` so it's not that important to have and we could perhaps just drop it.

