### PR TITLE
Drop extra fromIntegral

### DIFF
--- a/src/System/Remote/Monitoring/Influxdb.hs
+++ b/src/System/Remote/Monitoring/Influxdb.hs
@@ -131,7 +131,7 @@ loop store opts params = forever $ do
   flushSample sample params opts
   end <- getCurrentTime
   let diff :: Int
-      diff = fromIntegral (truncate (diffUTCTime end start * 1000))
+      diff = truncate (diffUTCTime end start * 1000)
   threadDelay (flushInterval opts * 1000 - diff)
 
 flushSample :: EKG.Sample -> Influxdb.WriteParams -> InfluxdbOptions -> IO ()


### PR DESCRIPTION
I *think* this `fromIntegral` is extra (at least after the version bump in PR #3).